### PR TITLE
Update Centos tests

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,7 +30,8 @@ jobs:
           - geerlingguy/docker-ubuntu2004-ansible:latest
           - geerlingguy/docker-ubuntu1804-ansible:latest
           - geerlingguy/docker-ubuntu1604-ansible:latest
-          - geerlingguy/docker-centos6-ansible:latest
+          - geerlingguy/docker-centos7-ansible:latest
+          - geerlingguy/docker-centos8-ansible:latest
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
6 is dead. Add 7 and 8, see how they do instead.